### PR TITLE
Make set update value and TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ func main() {
 }
 ```
 
-## Note
-Setting a value twice does not reset its expiration timer.
 
 ## License
 Copyright (c) 2017 Johan Sageryd <j@1616.se>

--- a/qcache.go
+++ b/qcache.go
@@ -81,13 +81,8 @@ func (c *Cache) Get(key interface{}) (interface{}, bool) {
 	return nil, false
 }
 
-// Set sets the given key to the given value. If the given key already exists,
-// Set is a no-op.
+// Set sets the given key to the given value.
 func (c *Cache) Set(key interface{}, value interface{}) {
-	if _, ok := c.Get(key); ok {
-		return
-	}
-
 	c.mu.Lock()
 
 	i := &item{
@@ -139,7 +134,9 @@ func (c *Cache) expire() {
 	}
 
 	for _, item := range c.queue[:offset] {
-		delete(c.items, item.key)
+		if i, ok := c.items[item.key]; ok && i.expires == item.expires {
+			delete(c.items, item.key)
+		}
 	}
 
 	c.queue = c.queue[offset:]

--- a/qcache_test.go
+++ b/qcache_test.go
@@ -134,6 +134,32 @@ func TestSetExisting(t *testing.T) {
 	}
 }
 
+func TestSetUpdatesTTL(t *testing.T) {
+	c := New(50 * time.Millisecond)
+	c.Set("key", "value")
+	time.Sleep(30 * time.Millisecond)
+	c.Set("key", "value")
+	time.Sleep(30 * time.Millisecond)
+	gotValue, ok := c.Get("key")
+
+	if gotValue != "value" || !ok {
+		t.Errorf(`c.Get("key") = %v, %t; want "value", true`, gotValue, ok)
+	}
+}
+
+func TestSetUpdatesValue(t *testing.T) {
+	c := New(50 * time.Millisecond)
+	c.Set("key", "value")
+	time.Sleep(30 * time.Millisecond)
+	c.Set("key", "value2")
+	time.Sleep(30 * time.Millisecond)
+	gotValue, ok := c.Get("key")
+
+	if gotValue != "value2" || !ok {
+		t.Errorf(`c.Get("key") = %v, %t; want "value", true`, gotValue, ok)
+	}
+}
+
 func TestSize(t *testing.T) {
 	c := New(10*time.Millisecond, WithMaxPurgeInterval(0))
 


### PR DESCRIPTION
When using Set it is useful to extend the TTL and also then you need
to be able to update the value to be up to date..